### PR TITLE
Update badges for consistency across libp2p repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-conn-security-multistream
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![GoDoc](https://godoc.org/github.com/libp2p/go-conn-security-multistream?status.svg)](https://godoc.org/github.com/libp2p/go-conn-security-multistream)
 [![Coverage Status](https://coveralls.io/repos/github/libp2p/go-conn-security-multistream/badge.svg?branch=master)](https://coveralls.io/github/libp2p/go-conn-security-multistream?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # go-conn-security-multistream
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
-[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![GoDoc](https://godoc.org/github.com/libp2p/go-conn-security-multistream?status.svg)](https://godoc.org/github.com/libp2p/go-conn-security-multistream)
-[![Coverage Status](https://coveralls.io/repos/github/libp2p/go-conn-security-multistream/badge.svg?branch=master)](https://coveralls.io/github/libp2p/go-conn-security-multistream?branch=master)
-[![Build Status](https://travis-ci.org/libp2p/go-conn-security-multistream.svg?branch=master)](https://travis-ci.org/libp2p/go-conn-security-multistream)
 
 > Connection security multistream multiplexer
 


### PR DESCRIPTION
This is one of many PRs to get our README badges all consistently
referring to libp2p in places where they currently refer to IPFS.

The changes are:

- any existing "Made by Protocol Labs" badges that link to `ipn.io` have been
changed to link to `protocol.ai`
- the project badge has been changed to libp2p, with the yellow color
- the IRC badge links to the `#libp2p` channel
- the "Made by PL", project, and IRC badges appear in that order
- the Standard Readme badge has been removed, if present
- badges for Travis CI have been removed if the current state is "unknown" and
this repo lacks a `.travis.yml` file
- badges for Coveralls have been removed if the state is "unknown"


Since this is a cookie-cutter message shared by many PRs to various repos,
some of the changes above may not apply to this specific PR.