### PR TITLE
block while writing

### DIFF
--- a/ssms.go
+++ b/ssms.go
@@ -82,6 +82,7 @@ func (sm *SSMuxer) selectProto(ctx context.Context, insecure net.Conn, server bo
 		// We *must* do this. We have outstanding work on the connection
 		// and it's no longer safe to use.
 		insecure.Close()
+		<-done // wait to stop using the connection.
 		return nil, ctx.Err()
 	}
 }


### PR DESCRIPTION
Make sure to wait until we're done writing before returning. The close should interrupt this process but we should still wait.

might be related to https://github.com/ipfs/go-ipfs/issues/6197